### PR TITLE
Add FastAPI-based PyCaret copilot stack with Streamlit UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.swp
+.env
+artifacts/
+uploaded/
+*.html
+*.pkl
+.venv/
+.pytest_cache/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
-pyCaretMess
+# PyCaret Copilot Stack
+
+A reference implementation of a PyCaret-focused agent that combines automated EDA,
+rule-based planner logic, and a conversational interface. The repository contains:
+
+- **FastAPI backend** (`agent_service/`) with endpoints for chat, automated EDA, and
+  PyCaret experiment execution.
+- **Tooling layer** that generates Sweetviz and YData-Profiling reports and derives
+  PyCaret `setup()` recommendations from dataset heuristics.
+- **Streamlit frontend** (`frontend/`) that offers a lightweight chat-like interface for
+  uploading datasets and triggering backend actions.
+- **Unit tests** validating planner routing decisions.
+
+## Getting started
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Export your OpenRouter API key (needed only for live LLM chat):
+
+   ```bash
+   export OPENROUTER_API_KEY="sk-..."
+   ```
+
+3. Launch the backend:
+
+   ```bash
+   uvicorn agent_service.main:app --reload
+   ```
+
+4. In a separate terminal start the Streamlit UI:
+
+   ```bash
+   streamlit run frontend/streamlit_app.py
+   ```
+
+Upload a dataset through the UI to generate automated EDA reports or trigger PyCaret
+model training. For scripted usage you can POST directly to `/chat` or `/actions`.
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+pytest
+```
+
+## Project layout
+
+```
+agent_service/
+  config.py          # Environment-driven configuration
+  llm_client.py      # OpenRouter HTTP client wrapper
+  main.py            # FastAPI entrypoint
+  planner.py         # Rule-based decision maker
+  schemas.py         # Pydantic models
+  tools.py           # EDA + PyCaret orchestration helpers
+frontend/
+  streamlit_app.py   # Lightweight chat UI
+requirements.txt      # Python dependencies
+```
+
+Automated EDA artifacts are written to the `artifacts/` directory by default.

--- a/agent_service/__init__.py
+++ b/agent_service/__init__.py
@@ -1,0 +1,3 @@
+"""Agent service package exposing FastAPI app and helper utilities."""
+
+__all__ = []

--- a/agent_service/config.py
+++ b/agent_service/config.py
@@ -1,0 +1,36 @@
+"""Configuration utilities for the agent service."""
+
+from functools import lru_cache
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    openrouter_api_key: str | None = Field(
+        default=None,
+        description="API key used to authenticate against OpenRouter endpoints.",
+        env="OPENROUTER_API_KEY",
+    )
+    openrouter_base_url: str = Field(
+        default="https://openrouter.ai/api/v1",
+        description="Base URL for OpenRouter compatible chat completions endpoint.",
+    )
+    llm_model: str = Field(
+        default="anthropic/claude-3-sonnet",
+        description="Default model identifier sent to the LLM provider.",
+    )
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return cached application settings."""
+
+    return Settings()
+
+
+__all__ = ["Settings", "get_settings"]

--- a/agent_service/llm_client.py
+++ b/agent_service/llm_client.py
@@ -1,0 +1,71 @@
+"""HTTP client for interacting with OpenRouter compatible language models."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+import requests
+
+from .config import get_settings
+from .schemas import ChatMessage
+
+LOGGER = logging.getLogger(__name__)
+
+
+class LLMClientError(RuntimeError):
+    """Raised when an upstream LLM provider returns an error."""
+
+
+class LLMClient:
+    """Thin wrapper around the OpenRouter chat completions API."""
+
+    def __init__(self) -> None:
+        self.settings = get_settings()
+
+    def _format_messages(self, messages: Iterable[ChatMessage]) -> list[dict[str, str]]:
+        return [
+            {"role": message.role, "content": message.content}
+            for message in messages
+        ]
+
+    def chat(self, messages: Iterable[ChatMessage]) -> str:
+        """Send a chat completion request to the configured model."""
+
+        if not self.settings.openrouter_api_key:
+            raise LLMClientError(
+                "OPENROUTER_API_KEY is not configured; unable to reach the LLM provider."
+            )
+
+        headers = {
+            "Authorization": f"Bearer {self.settings.openrouter_api_key}",
+            "HTTP-Referer": "https://example.com",
+            "X-Title": "PyCaret Copilot",
+        }
+        payload = {
+            "model": self.settings.llm_model,
+            "messages": self._format_messages(messages),
+        }
+
+        response = requests.post(
+            f"{self.settings.openrouter_base_url}/chat/completions",
+            json=payload,
+            headers=headers,
+            timeout=60,
+        )
+        if response.status_code != 200:
+            LOGGER.error("LLM provider error %s: %s", response.status_code, response.text)
+            raise LLMClientError(
+                f"OpenRouter request failed with {response.status_code}: {response.text[:200]}"
+            )
+
+        data = response.json()
+        try:
+            return data["choices"][0]["message"]["content"].strip()
+        except (KeyError, IndexError) as exc:
+            raise LLMClientError(
+                "Unexpected response format received from OpenRouter."
+            ) from exc
+
+
+__all__ = ["LLMClient", "LLMClientError"]

--- a/agent_service/main.py
+++ b/agent_service/main.py
@@ -1,0 +1,119 @@
+"""FastAPI entrypoint exposing chat and action endpoints."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+
+from fastapi import FastAPI, HTTPException
+
+from .config import get_settings
+from .llm_client import LLMClient, LLMClientError
+from .planner import Planner
+from .schemas import ActionRequest, ActionResponse, ChatRequest, ChatResponse
+from .tools import (
+    load_dataset,
+    profile_dataset,
+    recommend_pycaret_setup,
+    run_pycaret_experiment,
+    summarize_recommendation,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def create_app() -> FastAPI:
+    """Construct the FastAPI application."""
+
+    settings = get_settings()
+    planner = Planner()
+    llm_client = LLMClient()
+
+    app = FastAPI(title="PyCaret Copilot Agent", version="0.1.0")
+
+    @app.get("/health", tags=["system"])
+    async def health() -> dict[str, str]:
+        return {"status": "ok", "model": settings.llm_model}
+
+    @app.post("/chat", response_model=ChatResponse, tags=["chat"])
+    async def chat(request: ChatRequest) -> ChatResponse:
+        decision = planner.decide(request.messages)
+        conversation_id = request.conversation_id or str(uuid.uuid4())
+
+        if decision.action == "generate_eda":
+            if not request.dataset_path:
+                raise HTTPException(
+                    status_code=400, detail="dataset_path is required for EDA generation."
+                )
+            artifacts = profile_dataset(request.dataset_path, request.target)
+            reply = (
+                "Generated automated EDA artifacts. "
+                "Sweetviz and YData-Profiling reports are ready for review."
+            )
+            return ChatResponse(
+                conversation_id=conversation_id,
+                reply=reply,
+                planner_action=decision.action,
+                artifacts=artifacts,
+            )
+
+        if decision.action == "run_pycaret":
+            if not request.dataset_path or not request.target:
+                raise HTTPException(
+                    status_code=400,
+                    detail="dataset_path and target are required to launch PyCaret experiments.",
+                )
+            dataframe = load_dataset(request.dataset_path)
+            recommendation = recommend_pycaret_setup(dataframe, request.target)
+            summary = summarize_recommendation(recommendation)
+            reply = (
+                "Prepared PyCaret setup recommendations based on dataset heuristics. "
+                "You can execute the experiment via the /actions endpoint."
+            )
+            return ChatResponse(
+                conversation_id=conversation_id,
+                reply=f"{reply}\n\n{summary}",
+                planner_action=decision.action,
+                artifacts={"recommendation": recommendation},
+            )
+
+        try:
+            response_text = llm_client.chat(request.messages)
+        except LLMClientError as exc:  # pragma: no cover - requires API key
+            LOGGER.exception("LLM provider error")
+            raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+        return ChatResponse(
+            conversation_id=conversation_id,
+            reply=response_text,
+            planner_action=decision.action,
+        )
+
+    @app.post("/actions", response_model=ActionResponse, tags=["actions"])
+    async def actions(request: ActionRequest) -> ActionResponse:
+        if request.action == "generate_eda":
+            artifacts = profile_dataset(request.dataset_path, request.target)
+            return ActionResponse(
+                action=request.action,
+                detail="Generated Sweetviz and YData-Profiling reports.",
+                artifacts=artifacts,
+            )
+
+        if request.action == "run_pycaret":
+            if not request.target:
+                raise HTTPException(status_code=400, detail="target is required for PyCaret runs.")
+            result = run_pycaret_experiment(request.dataset_path, request.target)
+            detail = (
+                "PyCaret experiment finished. Model saved to {model_path} and leaderboard at {leaderboard}."
+            ).format(
+                model_path=result["model_path"], leaderboard=result["leaderboard_path"]
+            )
+            return ActionResponse(action=request.action, detail=detail, artifacts=result)
+
+        raise HTTPException(status_code=400, detail=f"Unknown action {request.action}")
+
+    return app
+
+
+app = create_app()

--- a/agent_service/planner.py
+++ b/agent_service/planner.py
@@ -1,0 +1,55 @@
+"""Simple planner that decides which tool or response strategy to execute."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Protocol
+
+
+class SupportsMessage(Protocol):
+    """Protocol representing minimal chat message attributes."""
+
+    role: str
+    content: str
+
+
+@dataclass(slots=True)
+class PlannerDecision:
+    """Represents the planner decision and optional metadata."""
+
+    action: str
+    rationale: str
+
+
+class Planner:
+    """Rule based planner inspired by agent orchestration frameworks."""
+
+    def decide(self, messages: Iterable[SupportsMessage]) -> PlannerDecision:
+        """Decide the next action based on the latest user message."""
+
+        try:
+            last_message = next(
+                message for message in reversed(list(messages)) if message.role == "user"
+            )
+        except StopIteration:
+            return PlannerDecision(
+                action="plain_chat", rationale="No user message provided; defaulting to chat."
+            )
+
+        text = last_message.content.lower()
+        if any(keyword in text for keyword in {"sweetviz", "ydata", "eda"}):
+            return PlannerDecision(
+                action="generate_eda",
+                rationale="Detected request for automated EDA tooling (Sweetviz/YData).",
+            )
+
+        if "pycaret" in text or "train" in text:
+            return PlannerDecision(
+                action="run_pycaret",
+                rationale="Detected modeling intent referencing PyCaret or training instructions.",
+            )
+
+        return PlannerDecision(action="plain_chat", rationale="Defaulting to LLM chat response.")
+
+
+__all__ = ["Planner", "PlannerDecision"]

--- a/agent_service/schemas.py
+++ b/agent_service/schemas.py
@@ -1,0 +1,66 @@
+"""Pydantic schemas shared across FastAPI routes."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class ChatMessage(BaseModel):
+    """Represents a single chat message."""
+
+    role: Literal["user", "assistant", "system"]
+    content: str
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ChatRequest(BaseModel):
+    """Request payload for /chat endpoint."""
+
+    conversation_id: str | None = Field(
+        default=None, description="Client supplied identifier for the conversation."
+    )
+    messages: list[ChatMessage]
+    dataset_path: str | None = Field(
+        default=None,
+        description="Optional relative path to a dataset that the agent can access for EDA.",
+    )
+    target: str | None = Field(
+        default=None, description="Optional target column used for modeling tasks."
+    )
+
+
+class ChatResponse(BaseModel):
+    """Response payload returned from /chat endpoint."""
+
+    conversation_id: str
+    reply: str
+    planner_action: str
+    artifacts: dict[str, Any] | None = None
+
+
+class ActionRequest(BaseModel):
+    """Request payload for direct tool execution."""
+
+    action: Literal["generate_eda", "run_pycaret"]
+    dataset_path: str
+    target: str | None = None
+
+
+class ActionResponse(BaseModel):
+    """Response returned after executing a tool directly."""
+
+    action: str
+    detail: str
+    artifacts: dict[str, Any] | None = None
+
+
+__all__ = [
+    "ChatMessage",
+    "ChatRequest",
+    "ChatResponse",
+    "ActionRequest",
+    "ActionResponse",
+]

--- a/agent_service/tools.py
+++ b/agent_service/tools.py
@@ -1,0 +1,200 @@
+"""Tools for automated EDA generation and PyCaret experiment orchestration."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+import pandas as pd
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _load_dataset(dataset_path: str) -> pd.DataFrame:
+    path = Path(dataset_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset not found at {path}")
+
+    if path.suffix.lower() in {".csv", ".txt"}:
+        return pd.read_csv(path)
+    if path.suffix.lower() in {".parquet"}:
+        return pd.read_parquet(path)
+
+    raise ValueError(f"Unsupported dataset format for {path.suffix}")
+
+
+def load_dataset(dataset_path: str) -> pd.DataFrame:
+    """Public wrapper that loads a dataset into a dataframe."""
+
+    return _load_dataset(dataset_path)
+
+
+def _looks_like_id(column: str, series: pd.Series) -> bool:
+    unique_ratio = series.nunique(dropna=True) / max(len(series), 1)
+    return unique_ratio > 0.98 or column.lower().endswith("id")
+
+
+def profile_dataset(
+    dataset_path: str, target: str | None = None, output_dir: str | Path = "artifacts"
+) -> dict[str, str]:
+    """Generate Sweetviz and YData-Profiling reports for the provided dataset."""
+
+    try:
+        from ydata_profiling import ProfileReport
+    except Exception as exc:  # pragma: no cover - heavy optional dependency
+        raise RuntimeError("ydata_profiling is required to generate profile reports") from exc
+
+    try:
+        import sweetviz as sv
+    except Exception as exc:  # pragma: no cover - heavy optional dependency
+        raise RuntimeError("sweetviz is required to generate Sweetviz reports") from exc
+
+    df = _load_dataset(dataset_path)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    profile_path = output_dir / "ydata_profile.html"
+    profile = ProfileReport(df, title="Dataset Profile", explorative=True)
+    profile.to_file(profile_path)
+
+    sweetviz_path = output_dir / "sweetviz_report.html"
+    if target and target in df.columns:
+        report = sv.analyze(df, target_feat=target)
+    else:
+        report = sv.analyze(df)
+    report.show_html(str(sweetviz_path), open_browser=False)
+
+    return {
+        "ydata_profile": str(profile_path),
+        "sweetviz_report": str(sweetviz_path),
+    }
+
+
+def _numeric_skew(df: pd.DataFrame) -> dict[str, float]:
+    numeric_cols = df.select_dtypes(include=[np.number])
+    return numeric_cols.skew(numeric_only=True).fillna(0.0).to_dict() if not numeric_cols.empty else {}
+
+
+def _missingness(df: pd.DataFrame) -> dict[str, float]:
+    return {column: float(df[column].isna().mean()) for column in df.columns}
+
+
+def recommend_pycaret_setup(df: pd.DataFrame, target: str | None) -> dict[str, Any]:
+    """Derive PyCaret setup keyword arguments based on dataset heuristics."""
+
+    ignore_features: list[str] = []
+    missing = _missingness(df)
+    skew = _numeric_skew(df)
+
+    for column in df.columns:
+        series = df[column]
+        if _looks_like_id(column, series) or missing[column] > 0.4:
+            ignore_features.append(column)
+
+    task = "unsupervised"
+    metric = None
+    if target and target in df.columns:
+        target_series = df[target]
+        if pd.api.types.is_numeric_dtype(target_series) and target_series.nunique() > 15:
+            task = "regression"
+            metric = "R2"
+        else:
+            task = "classification"
+            metric = "AUC"
+
+    transform_cols = [col for col, value in skew.items() if abs(value) > 1.0]
+
+    setup_kwargs = {
+        "target": target,
+        "normalize": True,
+        "transformation": bool(transform_cols),
+        "remove_multicollinearity": True,
+        "multicollinearity_threshold": 0.95,
+        "fix_imbalance": False,
+        "ignore_features": ignore_features,
+        "session_id": 42,
+    }
+
+    if task == "classification" and target:
+        distribution = df[target].value_counts(normalize=True)
+        if not distribution.empty and distribution.min() < 0.1:
+            setup_kwargs["fix_imbalance"] = True
+            setup_kwargs["fold_strategy"] = "stratifiedkfold"
+
+    return {
+        "task": task,
+        "metric": metric,
+        "transform_columns": transform_cols,
+        "setup_kwargs": setup_kwargs,
+    }
+
+
+def run_pycaret_experiment(
+    dataset_path: str,
+    target: str,
+    output_dir: str | Path = "artifacts",
+    additional_setup: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Execute a lightweight PyCaret experiment using the recommended configuration."""
+
+    df = _load_dataset(dataset_path)
+    recommendation = recommend_pycaret_setup(df, target)
+    setup_kwargs = {**recommendation["setup_kwargs"]}
+    if additional_setup:
+        setup_kwargs.update(additional_setup)
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if recommendation["task"] == "classification":
+        from pycaret.classification import ClassificationExperiment
+
+        experiment = ClassificationExperiment()
+    elif recommendation["task"] == "regression":
+        from pycaret.regression import RegressionExperiment
+
+        experiment = RegressionExperiment()
+    else:
+        raise RuntimeError("Target column required for supervised PyCaret experiments")
+
+    experiment.setup(data=df, **setup_kwargs)
+    top_models = experiment.compare_models(n_select=1, sort=recommendation["metric"] or "Accuracy")
+    best_model = top_models[0] if isinstance(top_models, Iterable) else top_models
+    model_path = output_dir / "best_model"
+    experiment.save_model(best_model, str(model_path))
+
+    leaderboard = experiment.pull()
+    leaderboard_path = output_dir / "leaderboard.json"
+    leaderboard.to_json(leaderboard_path, orient="records")
+
+    return {
+        "recommendation": recommendation,
+        "model_path": str(model_path) + ".pkl",
+        "leaderboard_path": str(leaderboard_path),
+    }
+
+
+def summarize_recommendation(recommendation: dict[str, Any]) -> str:
+    """Render a human readable explanation of the recommended setup."""
+
+    setup_kwargs = recommendation["setup_kwargs"]
+    summary = {
+        "task": recommendation["task"],
+        "metric": recommendation["metric"],
+        "transformation": setup_kwargs.get("transformation"),
+        "ignore_features": setup_kwargs.get("ignore_features"),
+        "fix_imbalance": setup_kwargs.get("fix_imbalance"),
+    }
+    return json.dumps(summary, indent=2)
+
+
+__all__ = [
+    "load_dataset",
+    "profile_dataset",
+    "recommend_pycaret_setup",
+    "run_pycaret_experiment",
+    "summarize_recommendation",
+]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,34 @@
+# PyCaret Copilot Frontend
+
+This directory contains a lightweight Streamlit interface that talks to the FastAPI
+backend. It provides a minimal chat-like workflow for uploading datasets, triggering
+automated EDA, and running PyCaret experiments.
+
+## Running locally
+
+1. Install Python dependencies from the project root:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Start the backend API (from the repository root):
+
+   ```bash
+   uvicorn agent_service.main:app --reload
+   ```
+
+3. In a separate terminal, launch Streamlit:
+
+   ```bash
+   streamlit run frontend/streamlit_app.py
+   ```
+
+4. Enter your OpenRouter API key in the environment before launching the backend:
+
+   ```bash
+   export OPENROUTER_API_KEY="sk-..."
+   ```
+
+The interface allows you to upload a CSV file, inspect planner decisions, and trigger
+the `/actions` endpoints exposed by the backend service.

--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -1,0 +1,87 @@
+"""Streamlit interface for the PyCaret copilot backend."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import requests
+import streamlit as st
+
+API_URL = st.secrets.get("api_url", "http://localhost:8000")
+
+
+@st.cache_data
+def save_uploaded_file(upload) -> Path:
+    output_dir = Path("uploaded")
+    output_dir.mkdir(exist_ok=True)
+    path = output_dir / f"{uuid.uuid4()}_{upload.name}"
+    with path.open("wb") as handle:
+        handle.write(upload.getbuffer())
+    return path
+
+
+def render_chat():
+    st.title("PyCaret Copilot")
+    st.write("Interact with the backend agent and trigger automated workflows.")
+
+    uploaded_file = st.file_uploader("Dataset (CSV/Parquet)")
+    dataset_path: Path | None = None
+    if uploaded_file:
+        dataset_path = save_uploaded_file(uploaded_file)
+        st.success(f"Saved dataset to {dataset_path}")
+
+    target = st.text_input("Target column (optional)")
+
+    user_prompt = st.text_area("Message", "Generate an EDA report for this dataset")
+    if st.button("Send"):
+        messages = [{"role": "user", "content": user_prompt}]
+        payload = {
+            "messages": messages,
+            "conversation_id": str(uuid.uuid4()),
+            "dataset_path": str(dataset_path) if dataset_path else None,
+            "target": target or None,
+        }
+        response = requests.post(f"{API_URL}/chat", json=payload, timeout=60)
+        if response.status_code != 200:
+            st.error(f"Backend error: {response.text}")
+            return
+        data = response.json()
+        st.subheader("Agent Response")
+        st.write(data["reply"])
+        st.write(f"Planner action: `{data['planner_action']}`")
+        if data.get("artifacts"):
+            st.write("Artifacts:")
+            st.json(data["artifacts"])
+
+    st.markdown("---")
+    st.subheader("Manual actions")
+    col1, col2 = st.columns(2)
+    with col1:
+        if st.button("Generate EDA", key="eda"):
+            if not dataset_path:
+                st.warning("Upload a dataset first")
+            else:
+                payload = {
+                    "action": "generate_eda",
+                    "dataset_path": str(dataset_path),
+                    "target": target or None,
+                }
+                response = requests.post(f"{API_URL}/actions", json=payload, timeout=120)
+                st.write(response.json())
+    with col2:
+        if st.button("Run PyCaret", key="pycaret"):
+            if not dataset_path or not target:
+                st.warning("Upload a dataset and set a target")
+            else:
+                payload = {
+                    "action": "run_pycaret",
+                    "dataset_path": str(dataset_path),
+                    "target": target,
+                }
+                response = requests.post(f"{API_URL}/actions", json=payload, timeout=600)
+                st.write(response.json())
+
+
+if __name__ == "__main__":
+    render_chat()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+fastapi>=0.110.0
+uvicorn[standard]>=0.27.0
+requests>=2.31.0
+pydantic>=1.10.0,<2.0.0
+pandas>=1.5.0
+numpy>=1.24.0
+sweetviz>=2.3.1
+ydata-profiling>=4.6.0
+pycaret>=3.0.0
+mlflow>=2.10.0
+streamlit>=1.32.0
+pytest>=7.4.0

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,42 @@
+"""Unit tests for the planner module."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agent_service.planner import Planner
+
+
+@dataclass
+class DummyMessage:
+    role: str
+    content: str
+    timestamp: datetime
+
+
+def _message(content: str) -> DummyMessage:
+    return DummyMessage(role="user", content=content, timestamp=datetime.utcnow())
+
+
+def test_detects_eda_keywords():
+    planner = Planner()
+    decision = planner.decide([_message("please run sweetviz")])
+    assert decision.action == "generate_eda"
+    assert "EDA" in decision.rationale
+
+
+def test_detects_pycaret_requests():
+    planner = Planner()
+    decision = planner.decide([_message("train a pycaret model")])
+    assert decision.action == "run_pycaret"
+
+
+def test_defaults_to_plain_chat():
+    planner = Planner()
+    decision = planner.decide([_message("hello there")])
+    assert decision.action == "plain_chat"


### PR DESCRIPTION
## Summary
- scaffold a FastAPI backend that exposes chat, automated EDA, and PyCaret execution endpoints
- add reusable tooling for generating Sweetviz/YData reports and deriving PyCaret setup recommendations
- include a Streamlit-based frontend and unit tests covering the planner routing logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da60b21e3883328b23258b1d83cf7f